### PR TITLE
let transport of Discord work properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ jspm_packages
 # config
 config.js
 badwords.js
+
+# other
+package-lock.json

--- a/config.example.js
+++ b/config.example.js
@@ -6,7 +6,7 @@
 
 module.exports = {
     "IRC": {
-        "disabled": false,                  // 設為 true 之後會禁止 IRC 機器人
+        "disabled": true,                  // 設為 true 之後會禁止 IRC 機器人
         "bot": {
             "server": "irc.freenode.net",
             "nick": "",                     // IRC 暱稱
@@ -49,7 +49,7 @@ module.exports = {
       注意：QQ 機器人需要與酷 Q 和 https://github.com/mrhso/cqsocketapi 配合使用！
      */
     "QQ": {
-        "disabled": false,                  // 設定為 true 後會禁止 QQ 機器人
+        "disabled": true,                  // 設定為 true 後會禁止 QQ 機器人
         "qq": "10000",                      // Bot 的 QQ 號碼
         "options": {
             "selfCensorship": true,         // 敏感詞列表，位於 badwords.js
@@ -91,6 +91,7 @@ module.exports = {
             [
                 'irc/#test',
                 'telegram/-12345678',       // Telegram 群組號碼：可以先把 bot 拉到群組中，然後透過 /thisgroupid 來取得 id
+                'Discord/1234567898765432123',
                 'qq/12345678'
                 // 'QQ/87654321'            // 如果有這種需求，亦可以連接
             ]

--- a/config.example.js
+++ b/config.example.js
@@ -6,7 +6,7 @@
 
 module.exports = {
     "IRC": {
-        "disabled": true,                  // 設為 true 之後會禁止 IRC 機器人
+        "disabled": false,                  // 設為 true 之後會禁止 IRC 機器人
         "bot": {
             "server": "irc.freenode.net",
             "nick": "",                     // IRC 暱稱
@@ -49,7 +49,7 @@ module.exports = {
       注意：QQ 機器人需要與酷 Q 和 https://github.com/mrhso/cqsocketapi 配合使用！
      */
     "QQ": {
-        "disabled": true,                  // 設定為 true 後會禁止 QQ 機器人
+        "disabled": false,                  // 設定為 true 後會禁止 QQ 機器人
         "qq": "10000",                      // Bot 的 QQ 號碼
         "options": {
             "selfCensorship": true,         // 敏感詞列表，位於 badwords.js

--- a/lib/handlers/DiscordMessageHandler.js
+++ b/lib/handlers/DiscordMessageHandler.js
@@ -46,10 +46,10 @@ class DiscordMessageHandler extends MessageHandler {
                         client: 'Discord',
                         type: 'photo',
                         id: p.id,
-                        size: p.filesize,
+                        size: p.size,
                         url: this._useProxyURL ? p.proxyURL : p.url,
                     }];
-                    text += ` <photo: ${p.width}x${p.height}, ${getFriendlySize(p.filesize)}>`;
+                    text += ` <photo: ${p.width}x${p.height}, ${getFriendlySize(p.size)}>`;
                 }
             }
 
@@ -100,7 +100,10 @@ class DiscordMessageHandler extends MessageHandler {
         } else if (this._keepSilence.indexOf(target) !== -1) {
             return Promise.resolve();
         } else {
-            this._client.channels.get(target).send(message);
+            this._client.channels.fetch(target)
+            .then(target_channel => {
+                (async () => await target_channel.send(message))()
+            });
             return Promise.resolve();
         }
     }

--- a/main.js
+++ b/main.js
@@ -265,7 +265,7 @@ if (config.Discord && !config.Discord.disabled) {
         useProxyURL: options.useProxyURL,
     };
 
-    const discordHandler = new DiscordMessageHandler(discordClient);
+    const discordHandler = new DiscordMessageHandler(discordClient, options2);
     pluginManager.handlers.set('Discord', discordHandler);
     pluginManager.handlerClasses.set('Discord', {
         object: DiscordMessageHandler,


### PR DESCRIPTION
Someing function of Discord behavior not work in the newer verson of discord.js.

新版本的discord.js似乎有變動，原有的程式碼在運行到涉及Discord消息轉發時會沒反應或報錯。經測試要改用fetch+await模式。
已經在最新版建置並測試於2023-10-09日的npm install狀態discord.js版本12.5.3。